### PR TITLE
Create ByteBuffer from byte array

### DIFF
--- a/wrappers/dotnet/indy-vdr-dotnet-tests/libindy-vdr/RequestApiTests.cs
+++ b/wrappers/dotnet/indy-vdr-dotnet-tests/libindy-vdr/RequestApiTests.cs
@@ -4,6 +4,7 @@ using indy_vdr_dotnet.libindy_vdr;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using System;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace indy_vdr_dotnet_tests.libindy_vdr
@@ -278,7 +279,7 @@ namespace indy_vdr_dotnet_tests.libindy_vdr
             IntPtr testRequestHandle = await LedgerApi.BuildGetTxnRequestAsync(1, 1);
             string testtestRequestBody = await RequestApi.RequestGetBodyAsync(testRequestHandle);
             JObject testtestRequestBodyJObj = JObject.Parse(testtestRequestBody);
-            string testMultiSig = "{\"signature\":\"sig\"}";
+            byte[] testMultiSig = Encoding.UTF8.GetBytes("{\"signature\":\"sig\"}");
 
             //Act
             Func<Task> func = async () => await RequestApi.RequestSetSigantureAsync(

--- a/wrappers/dotnet/indy-vdr-dotnet/libindy-vdr/RequestApi.cs
+++ b/wrappers/dotnet/indy-vdr-dotnet/libindy-vdr/RequestApi.cs
@@ -170,7 +170,7 @@ namespace indy_vdr_dotnet.libindy_vdr
         /// <exception cref="IndyVdrException">Throws if <paramref name="requestHandle"/> or <paramref name="signature"/> is invalid.</exception>
         public static async Task RequestSetSigantureAsync(
             IntPtr requestHandle,
-            string signature)
+            byte[] signature)
         {
             int errorCode = NativeMethods.indy_vdr_request_set_signature(
                 requestHandle,

--- a/wrappers/dotnet/indy-vdr-dotnet/models/Structures.cs
+++ b/wrappers/dotnet/indy-vdr-dotnet/models/Structures.cs
@@ -42,6 +42,18 @@ namespace indy_vdr_dotnet.models
                 }
                 return buffer;
             }
+
+            public static ByteBuffer Create(byte[] bytes)
+            {
+                ByteBuffer buffer = new ByteBuffer();
+                buffer.len = bytes.Length;
+                fixed (byte* bytebuffer_p = &bytes[0])
+                {
+                    buffer.value = bytebuffer_p;
+                }
+
+                return buffer;
+            }
         }
     }
 }


### PR DESCRIPTION
Adds the ability to create the ByteBuffer from byte[] which was necessary to create valid signatures with indy-sdk.

Signed-off-by: Sebastian Bickerle <sebastian.bickerle@main-incubator.com>